### PR TITLE
[FIX] paho mqtt repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-
-	  # fallback to using the latest cache if no exact match is found
+          # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
       - run: npm install
@@ -25,10 +25,10 @@ jobs:
       #     command: npm test
 
       - run:
-        name: Build
-        command: |
-          npm run builddist
-          npm run publish:prepare
+          name: Build
+          command: |
+            npm run builddist
+            npm run publish:prepare
 
       - save_cache:
           paths:

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "msgpack-lite": "^0.1.26",
     "node-fetch": "^2.2.1",
     "node-fetch-polyfill": "^2.0.6",
-    "paho-mqtt": "git+ssh:git@github.com:eclipse/paho.mqtt.javascript.git#master",
+    "paho-mqtt": "eclipse/paho.mqtt.javascript#master",
     "protobufjs": "^6.8.8",
     "sha256": "^0.2.0",
     "tiny-events": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3428,9 +3428,9 @@ pad-right@^0.2.2:
   dependencies:
     repeat-string "^1.5.2"
 
-"paho-mqtt@git+ssh:git@github.com:eclipse/paho.mqtt.javascript.git#master":
+paho-mqtt@eclipse/paho.mqtt.javascript#master:
   version "1.1.0"
-  resolved "git+ssh:git@github.com:eclipse/paho.mqtt.javascript.git#413f72920575f699f895ad1016283c053da9d4f0"
+  resolved "https://codeload.github.com/eclipse/paho.mqtt.javascript/tar.gz/9b761defeeb4a627db31d92ae1b0ca91b44b226e"
 
 pako@~0.2.0:
   version "0.2.9"


### PR DESCRIPTION
Using a `git+ssh`-schemed URL obliges to use a SSH private key; this pull request let yarn decide how to download the dependency.