### PR TITLE
FIX: Return objetcs instead unresolved promises

### DIFF
--- a/src/lib/api/Livechat.ts
+++ b/src/lib/api/Livechat.ts
@@ -22,7 +22,7 @@ import ApiBase from './api'
 export default class ApiLivechat extends ApiBase {
   credentials: ILivechatRoomCredentialAPI = {} as any
   login (guest: INewLivechatGuestAPI | any) { return this.grantVisitor(guest) }
-  async config () { return (await this.get('livechat/config', { token: this.credentials.token }, false)).config }
+  async config (params?: ILivechatTokenAPI) { return (await this.get('livechat/config', params, false)).config }
   async room () { return (await this.get('livechat/room', { token: this.credentials.token }, false)).room }
   closeChat ({ rid }: ILivechatRoom) { return this.post('livechat/room.close', { rid, token: this.credentials.token }, false) }
   transferChat ({ rid, department }: ILivechatRoom) { return (this.post('livechat/room.transfer', { rid, token: this.credentials.token, department }, false)) }
@@ -35,7 +35,6 @@ export default class ApiLivechat extends ApiBase {
     }
     return visitor
 	 }
-  agent ({ rid }: any) { return this.get(`livechat/agent.info/${rid}/${this.credentials.token}`) }
   async agent ({ rid }: any) { return (await this.get(`livechat/agent.info/${rid}/${this.credentials.token}`)).agent }
   async nextAgent ({ department }: any) { return (await this.get(`livechat/agent.next/${this.credentials.token}`, { department })).agent }
   sendMessage (message: INewLivechatMessageAPI) { return (this.post('livechat/message', { ...message, token: this.credentials.token }, false)) }

--- a/src/lib/api/Livechat.ts
+++ b/src/lib/api/Livechat.ts
@@ -36,12 +36,13 @@ export default class ApiLivechat extends ApiBase {
     return visitor
 	 }
   agent ({ rid }: any) { return this.get(`livechat/agent.info/${rid}/${this.credentials.token}`) }
-  nextAgent ({ department }: any) { return this.get(`livechat/agent.next/${this.credentials.token}`, { department }) }
+  async agent ({ rid }: any) { return (await this.get(`livechat/agent.info/${rid}/${this.credentials.token}`)).agent }
+  async nextAgent ({ department }: any) { return (await this.get(`livechat/agent.next/${this.credentials.token}`, { department })).agent }
   sendMessage (message: INewLivechatMessageAPI) { return (this.post('livechat/message', { ...message, token: this.credentials.token }, false)) }
   editMessage (id: string, message: INewLivechatMessageAPI) { return (this.put(`livechat/message/${id}`, message, false)) }
   deleteMessage (id: string, { rid }: ILivechatRoom) { return (this.del(`livechat/message/${id}`, { rid, token: this.credentials.token }, false)) }
   async loadMessages (rid: string, params?: ILivechatRoomMessagesAPI) { return (await this.get(`livechat/messages.history/${rid}`, { ...params, token: this.credentials.token }, false)).messages }
-  sendOfflineMessage (message: INewLivechatOfflineMessageAPI) { return (this.post('livechat/offline.message', { ...message, token: this.credentials.token }, false)) }
+  async sendOfflineMessage (message: INewLivechatOfflineMessageAPI) { return (await this.post('livechat/offline.message', { ...message, token: this.credentials.token }, false)).message }
   sendVisitorNavigation ({ rid }: ILivechatRoom, page: INewLivechatNavigationAPI) { return (this.post('livechat/page.visited', { token: this.credentials.token, rid, ...page }, false)) }
   requestTranscript (email: string, { rid }: ILivechatRoom) { return (this.post('livechat/transcript', { token: this.credentials.token, rid, email }, false)) }
   videoCall ({ rid }: ILivechatRoom) { return this.get(`livechat/video.call/${this.credentials.token}`, { rid }, false) }

--- a/src/lib/api/Livechat.ts
+++ b/src/lib/api/Livechat.ts
@@ -22,12 +22,12 @@ import ApiBase from './api'
 export default class ApiLivechat extends ApiBase {
   credentials: ILivechatRoomCredentialAPI = {} as any
   login (guest: INewLivechatGuestAPI | any) { return this.grantVisitor(guest) }
-  async config (params?: ILivechatTokenAPI) { return (await this.get('livechat/config', params, false)).config }
+  async config () { return (await this.get('livechat/config', { token: this.credentials.token }, false)).config }
   async room () { return (await this.get('livechat/room', { token: this.credentials.token }, false)).room }
   closeChat ({ rid }: ILivechatRoom) { return this.post('livechat/room.close', { rid, token: this.credentials.token }, false) }
   transferChat ({ rid, department }: ILivechatRoom) { return (this.post('livechat/room.transfer', { rid, token: this.credentials.token, department }, false)) }
   chatSurvey (survey: ILivechatRoomSurveyAPI) { return (this.post('livechat/room.survey', { rid: survey.rid, token: this.credentials.token, data: survey.data }, false)) }
-  visitor (params: ILivechatTokenAPI) { return this.get(`livechat/visitor/${params.token}`) }
+  visitor () { return this.get(`livechat/visitor/${this.credentials.token}`) }
   async grantVisitor (guest: INewLivechatGuestAPI) {
     const { visitor } = await this.post('livechat/visitor', guest, false)
     this.credentials = {

--- a/src/utils/livechat/config.ts
+++ b/src/utils/livechat/config.ts
@@ -14,7 +14,7 @@ async function config () {
 		${JSON.stringify(await livechat.config(), null, '\t')}
 
 		Get Livechat Config with Token \`livechat.config({ token })\`:
-		${JSON.stringify(await livechat.config(), null, '\t')}
+		${JSON.stringify(await livechat.config({ token }), null, '\t')}
 
 	`)
 }

--- a/src/utils/livechat/config.ts
+++ b/src/utils/livechat/config.ts
@@ -14,7 +14,7 @@ async function config () {
 		${JSON.stringify(await livechat.config(), null, '\t')}
 
 		Get Livechat Config with Token \`livechat.config({ token })\`:
-		${JSON.stringify(await livechat.config({ token }), null, '\t')}
+		${JSON.stringify(await livechat.config(), null, '\t')}
 
 	`)
 }

--- a/src/utils/livechat/visitors.ts
+++ b/src/utils/livechat/visitors.ts
@@ -21,7 +21,7 @@ Add new Livechat CustomFields \`livechat.sendCustomFields()\`:
 ${JSON.stringify(await livechat.sendCustomFields(mockCustomFields), null, '\t')}
 
 \`livechat.visitor()\`:
-${JSON.stringify(await livechat.visitor({ token }), null, '\t')}
+${JSON.stringify(await livechat.visitor(), null, '\t')}
 
 	`)
 }


### PR DESCRIPTION
- [x] Change some functions to make it return the response returned by endpoint instead the unresolved promise.

- [x]  Change some functions signatures, removed the params which contained the livechat token, change it to use the `credentials.token` available on the SDK. Affected functions below:
```
async config (params?: ILivechatTokenAPI)
visitor (params: ILivechatTokenAPI)
```
https://github.com/RocketChat/Rocket.Chat.Livechat/projects/2#card-16169691
