### PR TITLE
Add methodCall

### DIFF
--- a/src/lib/clients/Rocketchat.ts
+++ b/src/lib/clients/Rocketchat.ts
@@ -50,5 +50,6 @@ export default class RocketChatClient extends ClientRest implements ISocket {
   async onMessage (cb: ICallback): Promise<any> {
     return (await this.socket as IDriver).onMessage(cb)
   }
+  async methodCall (method: string, ...args: any[]): Promise<ISubscription> { return (await this.socket as IDriver).methodCall(method, ...args) }
 
 }

--- a/src/lib/drivers/ddp.ts
+++ b/src/lib/drivers/ddp.ts
@@ -582,4 +582,8 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
     }
     return message
   }
+
+  methodCall = (method: string, ...args: any[]): Promise<any> => {
+    return this.ddp.call(method, ...args)
+  }
 }

--- a/src/lib/drivers/index.ts
+++ b/src/lib/drivers/index.ts
@@ -51,6 +51,7 @@ export interface IDriver {
 
   notifyVisitorTyping(rid: string, username: string, typing: boolean, token: string): Promise<any>
 
+  methodCall (method: string, ...args: any[]): Promise<any>
 }
 
 export enum Protocols {

--- a/src/lib/drivers/mqtt.ts
+++ b/src/lib/drivers/mqtt.ts
@@ -126,4 +126,8 @@ export class MQTTDriver extends EventEmitter implements ISocket, IDriver {
   onStreamData (name: string, cb: ICallback): Promise<any> {
     return Promise.resolve(this.on(name, ({ fields: { args: [message] } }: any) => cb((message)))) as any
   }
+
+  methodCall = (method: string, ...args: any[]): Promise<any> => {
+    return Promise.resolve() as any
+  }
 }


### PR DESCRIPTION
This method is needed in order to help React Native app migration.
As time goes by we may add all call as proper methods and remove this one.
