### PR TITLE
[FIX] onStreamData args

### DIFF
--- a/src/lib/drivers/ddp.ts
+++ b/src/lib/drivers/ddp.ts
@@ -557,7 +557,7 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
   }
 
   onStreamData = (name: string, cb: ICallback): Promise<any> => {
-    return Promise.resolve(this.ddp.on(name, ({ fields: { args: [message] } }: any) => cb((message)))) as any
+    return Promise.resolve(this.ddp.on(name, (message: any) => cb((message)))) as any
   }
 
   onMessage = (cb: ICallback): void => {


### PR DESCRIPTION
There's some manual emits without message raising errors if someone listens to it.
Example: `this.emit('open')`