### PR TITLE
[FIX] onStreamData destructuring

### DIFF
--- a/src/lib/clients/Livechat.ts
+++ b/src/lib/clients/Livechat.ts
@@ -44,7 +44,7 @@ export default class LivechatClient extends LivechatRest implements ISocket {
   async onTyping (cb: ICallback): Promise<any> { return (await this.socket as IDriver).onTyping(cb) }
   async onAgentChange (rid: string, cb: ICallback) {
     await this.subscribe(this.livechatStream, rid)
-    this.onStreamData(this.livechatStream, ({ type, data }: any) => {
+    this.onStreamData(this.livechatStream, ({ fields: { args: [{ type, data }] } }: any) => {
       if (type === 'agentData') {
         cb(data)
       }
@@ -52,7 +52,7 @@ export default class LivechatClient extends LivechatRest implements ISocket {
   }
   async onAgentStatusChange(rid: string, cb:ICallback){
     await this.subscribe(this.livechatStream, rid);
-    this.onStreamData(this.livechatStream, ({ type, status }: any) => {
+    this.onStreamData(this.livechatStream, ({ fields: { args: [{ type, status }] } }: any) => {
       if (type === 'agentStatus') {
         cb(status)
       }


### PR DESCRIPTION
This PR fixes a bug introduced on https://github.com/RocketChat/Rocket.Chat.js.SDK/pull/55

Later PR is still relevant, because the code ddp emits information about current connection, like `this.emit('open')`.
In these cases, there's no object to destructure from.