### PR TITLE
Use local setup as per .env file

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,4 @@
+require('dotenv').config()
 import { INewUserAPI } from './interfaces'
 
 // The API user, should be provisioned on build with local Rocket.Chat


### PR DESCRIPTION
Now can use `.env` for local setup for this repository. 

Fixes #66  