### PR TITLE
Add agentId parameter when getting a new Livechat room

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -611,6 +611,7 @@ export interface ILivechatRoomCredentialAPI {
 export interface ILivechatRoom {
   rid: string
   department?: string
+  agentId?: string
 }
 
 /** Structure for livechat room messages api */

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -616,7 +616,7 @@ export interface ILivechatRoom {
 /** Structure to get(new) livechat room */
 export interface INewLivechatRoomCredentialAPI {
   rid?: string
-  department?: string
+  agentId?: string
 }
 
 /** Structure for livechat room messages api */

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -611,7 +611,12 @@ export interface ILivechatRoomCredentialAPI {
 export interface ILivechatRoom {
   rid: string
   department?: string
-  agentId?: string
+}
+
+/** Structure to get(new) livechat room */
+export interface INewLivechatRoomCredentialAPI {
+  rid?: string
+  department?: string
 }
 
 /** Structure for livechat room messages api */

--- a/src/lib/api/Livechat.ts
+++ b/src/lib/api/Livechat.ts
@@ -24,7 +24,7 @@ export default class ApiLivechat extends ApiBase {
   credentials: ILivechatRoomCredentialAPI = {} as any
   login (guest: INewLivechatGuestAPI | any) { return this.grantVisitor(guest) }
   async config (params?: ILivechatTokenAPI) { return (await this.get('livechat/config', params, false)).config }
-  async room (rid: string = '') { return (await this.get('livechat/room', { token: this.credentials.token, rid }, false)).room }
+  async room (params?: ILivechatRoom) { return (await this.get('livechat/room', { token: this.credentials.token, ...params }, false)).room }
   closeChat ({ rid }: ILivechatRoom) { return this.post('livechat/room.close', { rid, token: this.credentials.token }, false) }
   transferChat ({ rid, department }: ILivechatRoom) { return (this.post('livechat/room.transfer', { rid, token: this.credentials.token, department }, false)) }
   chatSurvey (survey: ILivechatRoomSurveyAPI) { return (this.post('livechat/room.survey', { rid: survey.rid, token: this.credentials.token, data: survey.data }, false)) }
@@ -38,7 +38,7 @@ export default class ApiLivechat extends ApiBase {
   }
   async deleteVisitor () { return (await this.del(`livechat/visitor/${this.credentials.token}`)).visitor}
   async updateVisitorStatus(status: string) { return (await this.post(`livechat/visitor.status`, { token: this.credentials.token, status })).status }
-  async nextAgent (department?: any) { return (await this.get(`livechat/agent.next/${this.credentials.token}`, { department })).agent }
+  async nextAgent (department: string = '' ) { return (await this.get(`livechat/agent.next/${this.credentials.token}`, { department })).agent }
   async agent ({ rid }: any) { return (await this.get(`livechat/agent.info/${rid}/${this.credentials.token}`)).agent }
   sendMessage (message: INewLivechatMessageAPI) { return (this.post('livechat/message', { ...message, token: this.credentials.token }, false)) }
   editMessage (id: string, message: INewLivechatMessageAPI) { return (this.put(`livechat/message/${id}`, message, false)) }

--- a/src/lib/api/Livechat.ts
+++ b/src/lib/api/Livechat.ts
@@ -14,7 +14,8 @@ import {
 	INewLivechatCustomFieldAPI,
 	INewLivechatOfflineMessageAPI,
 	INewLivechatCustomFieldsAPI,
-	ILivechatRoom,
+  ILivechatRoom,
+  INewLivechatRoomCredentialAPI,
 	ILivechatUploadAPI
 } from '../../interfaces'
 
@@ -24,7 +25,7 @@ export default class ApiLivechat extends ApiBase {
   credentials: ILivechatRoomCredentialAPI = {} as any
   login (guest: INewLivechatGuestAPI | any) { return this.grantVisitor(guest) }
   async config (params?: ILivechatTokenAPI) { return (await this.get('livechat/config', params, false)).config }
-  async room (params?: ILivechatRoom) { return (await this.get('livechat/room', { token: this.credentials.token, ...params }, false)).room }
+  async room (params?: INewLivechatRoomCredentialAPI) { return (await this.get('livechat/room', { token: this.credentials.token, ...params }, false)).room }
   closeChat ({ rid }: ILivechatRoom) { return this.post('livechat/room.close', { rid, token: this.credentials.token }, false) }
   transferChat ({ rid, department }: ILivechatRoom) { return (this.post('livechat/room.transfer', { rid, token: this.credentials.token, department }, false)) }
   chatSurvey (survey: ILivechatRoomSurveyAPI) { return (this.post('livechat/room.survey', { rid: survey.rid, token: this.credentials.token, data: survey.data }, false)) }

--- a/src/lib/api/Livechat.ts
+++ b/src/lib/api/Livechat.ts
@@ -14,8 +14,8 @@ import {
 	INewLivechatCustomFieldAPI,
 	INewLivechatOfflineMessageAPI,
 	INewLivechatCustomFieldsAPI,
-  ILivechatRoom,
-  INewLivechatRoomCredentialAPI,
+	ILivechatRoom,
+	INewLivechatRoomCredentialAPI,
 	ILivechatUploadAPI
 } from '../../interfaces'
 

--- a/src/utils/livechat/agents.ts
+++ b/src/utils/livechat/agents.ts
@@ -33,7 +33,7 @@ async function agent () {
 		${JSON.stringify(await livechat.agent({ rid, token }), null, '\t')}
 
 		Get Livechat Next Agent \`livechat.nextAgent()\`:
-		${JSON.stringify(await livechat.nextAgent({ token, department }), null, '\t')}
+		${JSON.stringify(await livechat.nextAgent(department), null, '\t')}
   `)
 }
 

--- a/src/utils/livechat/messages.ts
+++ b/src/utils/livechat/messages.ts
@@ -32,7 +32,6 @@ async function messages () {
   const editMessage = { token, rid, msg: 'editing livechat message..' }
   const result = await livechat.sendMessage(newMessage)
   const _id = result && result.message && result.message._id
-  const roomCredential = { token, rid }
   const pageInfo = Object.assign({}, mockVisitorNavigation, { rid })
 
   console.log(`

--- a/src/utils/livechat/visitors.ts
+++ b/src/utils/livechat/visitors.ts
@@ -4,7 +4,6 @@ import { mockVisitor, mockCustomField, mockCustomFields } from '../config'
 
 silence()
 const livechat = new Api({})
-const { token } = mockVisitor.visitor
 
 async function visitors () {
   console.log(`


### PR DESCRIPTION
Allows to define the agent who will attend the chat before getting a new livechat room.

Related to this PR -> https://github.com/RocketChat/Rocket.Chat/pull/14103