### PR TITLE
Set up Livechat connections

### DIFF
--- a/src/lib/clients/Livechat.ts
+++ b/src/lib/clients/Livechat.ts
@@ -76,4 +76,8 @@ export default class LivechatClient extends LivechatRest implements ISocket {
   async onStreamData (event: string, cb: ICallback): Promise<any> {
     return (await this.socket as ISocket).onStreamData(event, cb)
   }
+
+  async setUpConnection(data: any) {
+    return (await this.socket as IDriver).methodCall('livechat:setUpConnection', data)
+  }
 }

--- a/src/lib/clients/Livechat.ts
+++ b/src/lib/clients/Livechat.ts
@@ -33,7 +33,9 @@ export default class LivechatClient extends LivechatRest implements ISocket {
         throw new Error(`Invalid Protocol: ${protocol}, valids: ${Object.keys(Protocols).join()}`)
     }
   }
-  async connect (options: ISocketOptions, callback?: ICallback): Promise <any> { return (await this.socket as ISocket).connect(options) }
+  async connect (options: ISocketOptions, callback?: ICallback): Promise <any> {
+    return (await this.socket as ISocket).connect(options).then(() => (this.setUpConnection(options)))
+  }
   async disconnect (): Promise<any> { return (await this.socket as ISocket).disconnect() }
   async unsubscribe (subscription: ISubscription): Promise<any> { return (await this.socket as ISocket).unsubscribe(subscription) }
   async unsubscribeAll (): Promise<any> { return (await this.socket as ISocket).unsubscribeAll() }
@@ -77,7 +79,10 @@ export default class LivechatClient extends LivechatRest implements ISocket {
     return (await this.socket as ISocket).onStreamData(event, cb)
   }
 
-  async setUpConnection(data: any) {
-    return (await this.socket as IDriver).methodCall('livechat:setUpConnection', data)
+  async setUpConnection(options: any) {
+    if (!options || !options.token) return
+
+    const { token } = options;
+    return (await this.socket as IDriver).methodCall('livechat:setUpConnection', { token })
   }
 }

--- a/src/lib/clients/Livechat.ts
+++ b/src/lib/clients/Livechat.ts
@@ -34,7 +34,7 @@ export default class LivechatClient extends LivechatRest implements ISocket {
     }
   }
   async connect (options: ISocketOptions, callback?: ICallback): Promise <any> {
-    return (await this.socket as ISocket).connect(options).then(() => (this.setUpConnection(options)))
+    return (await this.socket as ISocket).connect(options).then(() => (this.setUpConnection()))
   }
   async disconnect (): Promise<any> { return (await this.socket as ISocket).disconnect() }
   async unsubscribe (subscription: ISubscription): Promise<any> { return (await this.socket as ISocket).unsubscribe(subscription) }
@@ -79,10 +79,8 @@ export default class LivechatClient extends LivechatRest implements ISocket {
     return (await this.socket as ISocket).onStreamData(event, cb)
   }
 
-  async setUpConnection(options: any) {
-    if (!options || !options.token) return
-
-    const { token } = options;
+  async setUpConnection() {
+    const { token } = this.credentials
     return (await this.socket as IDriver).methodCall('livechat:setUpConnection', { token })
   }
 }


### PR DESCRIPTION
Since we started using the REST API approach in client-server communication, when a connection was closed on the client side, the guest status was no longer being updated.
This PR adds a new method that will allow the server to configure the Livechat connections, handling the` onClose` event that will update the guest status when the connection is closed.