### PR TITLE
[FIX] Delete body

### DIFF
--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -136,9 +136,10 @@ class Client implements IClient {
     }).then(this.handle) as Promise<any>
   }
 
-  delete (url: string, options?: any): Promise<any> {
+  delete (url: string, data?: any, options?: any): Promise<any> {
     return fetch(`${this.host}/api/v1/${encodeURI(url)}`, {
       method: 'DELETE',
+      body: this.getBody(data),
       headers: this.getHeaders(options)
     }).then(this.handle) as Promise<any>
   }


### PR DESCRIPTION
When we go to delete `push.token` of user we need to send a `body` with `push.token`..
[Delete Push Token - Rocket.Chat](https://rocket.chat/docs/developer-guides/rest-api/push/deletepushtoken/)