### PR TITLE
potential bugfix for 3.8.0 versions

### DIFF
--- a/dist/lib/driver.js
+++ b/dist/lib/driver.js
@@ -129,7 +129,7 @@ function connect(options = {}, callback) {
 exports.connect = connect;
 /**
  * @memberof module:driver
- * @instance 
+ * @instance
  * @description Remove all active subscriptions, logout and disconnect from Rocket.Chat
  * @returns {Promise}
  */
@@ -192,7 +192,7 @@ exports.asyncCall = asyncCall;
  * @instance
  * @description Call a method as async ({@link module:driver#asyncCall|asyncCall}) via Asteroid,
  * or through cache ({@link module:driver#cacheCall|cacheCall}) if one is created.
- * 
+ *
  * If the method was called without parameters, they cannot be cached.
  * As the result, the method will always be called asynchronously.
  * @param {any} name - the Rocket.Chat server method to call through Asteroid
@@ -335,7 +335,7 @@ exports.unsubscribeAll = unsubscribeAll;
  * @memberof module:driver
  * @instance
  * @description Begin subscription to room events for user
- * 
+ *
  * > NOTE: Older adapters used an option for this method but it was always the default.
  * @param {string} [topic=stream-room-messages] - subscription topic
  * @param {number} [roomId=__my_messages__] - unique ID of the room to subscribe to
@@ -353,13 +353,13 @@ exports.subscribeToMessages = subscribeToMessages;
  * @memberof module:driver
  * @instance
  * @description Attach a callback to changes in the message stream.
- * 
+ *
  * This method should be used only after a subscription was created using
  * {@link module:driver#subscribeToMessages|subscribeToMessages}.
  * Fires callback with every change in subscriptions.
- * 
+ *
  * > NOTE: This method can be called directly for custom extensions, but for most usage
- * (e.g. for bots) the 
+ * (e.g. for bots) the
  * {@link module:driver#respondToMessages|respondToMessages} is more useful to only receive messages
  * matching configuration.
  *
@@ -439,6 +439,10 @@ function respondToMessages(callback, options = {}) {
             log_1.logger.error(`[received] Unable to receive: ${err.message}`);
             callback(err); // bubble errors back to adapter
         }
+
+        // Grab the first message in the list
+        message = message.shift()
+
         // Ignore bot's own messages
         if (message.u._id === exports.userId)
             return;
@@ -501,7 +505,7 @@ exports.getRoomName = getRoomName;
  * @memberof module:driver
  * @instance
  * @description Get ID for a DM room by its recipient's name.
- * 
+ *
  * The call will create a DM (with the bot) if it doesn't exist yet.
  * @param {string} username - recipient's username
  * @returns {Promise<roomId>}

--- a/src/lib/driver.ts
+++ b/src/lib/driver.ts
@@ -393,6 +393,9 @@ export function respondToMessages (
       callback(err) // bubble errors back to adapter
     }
 
+    // Grab the first message in the list
+    message = message.shift()
+
     // Ignore bot's own messages
     if (message.u._id === userId) return
 


### PR DESCRIPTION
We're seeing this error for hubot since upgrading to `3.8.0`:
```
[Tue Nov 17 2020 18:28:57 GMT+0000 (Coordinated Universal Time)] INFO [received] Message in room undefined
[Tue Nov 17 2020 18:28:57 GMT+0000 (Coordinated Universal Time)] ERROR TypeError: Cannot read property '_id' of undefined
  at Object.<anonymous> (/app/node_modules/hubot-rocketchat/node_modules/@rocket.chat/sdk/dist/lib/driver.js:374:23)
  at Generator.next (<anonymous>:null:null)
  at /app/node_modules/hubot-rocketchat/node_modules/@rocket.chat/sdk/dist/lib/driver.js:7:71
  at new Promise (<anonymous>:null:null)
  at __awaiter (/app/node_modules/hubot-rocketchat/node_modules/@rocket.chat/sdk/dist/lib/driver.js:3:12)
  at /app/node_modules/hubot-rocketchat/node_modules/@rocket.chat/sdk/dist/lib/driver.js:368:45
  at ReactiveQuery.<anonymous> (/app/node_modules/hubot-rocketchat/node_modules/@rocket.chat/sdk/dist/lib/driver.js:344:17)
  at /app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:170:12
  at Array.forEach (<anonymous>:null:null)
  at ReactiveQuery._emit (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:169:22)
  at Set.<anonymous> (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:749:8)
  at /app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:170:12
  at Array.forEach (<anonymous>:null:null)
  at Set._emit (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:169:22)
  at Set.put (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:965:7)
  at Set.<anonymous> (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:1020:8)
  at /app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:170:12
  at Array.forEach (<anonymous>:null:null)
  at Set._emit (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:169:22)
  at Set.put (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:965:7)
  at Collection._remoteToLocalUpdate (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:695:12)
  at Asteroid._onChanged (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:453:36)
  at DDP.<anonymous> (/app/node_modules/hubot-rocketchat/node_modules/asteroid/dist/asteroid.node.js:392:8)
  at /app/node_modules/ddp.js/src/ddp.js:125:12
  at Array.forEach (<anonymous>:null:null)
  at DDP._emit (/app/node_modules/ddp.js/src/ddp.js:124:22)
  at DDP._on_changed (/app/node_modules/ddp.js/src/ddp.js:248:8)
  at DDP._on_socket_message (/app/node_modules/ddp.js/src/ddp.js:326:26)
  at Client.dispatchEvent (/app/node_modules/faye-websocket/lib/faye/websocket/api/event_target.js:22:30)
  at Client._receiveMessage (/app/node_modules/faye-websocket/lib/faye/websocket/api.js:150:10)
  at Client.<anonymous> (/app/node_modules/faye-websocket/lib/faye/websocket/api.js:34:49)
  at Client.emit (node:events:339:22)
  at Client.<anonymous> (/app/node_modules/websocket-driver/lib/websocket/driver/hybi.js:454:14)
  at pipe (/app/node_modules/websocket-extensions/lib/pipeline/index.js:37:40)
  at Pipeline._loop (/app/node_modules/websocket-extensions/lib/pipeline/index.js:44:3)
  at Pipeline.processIncomingMessage (/app/node_modules/websocket-extensions/lib/pipeline/index.js:13:8)
  at Extensions.processIncomingMessage (/app/node_modules/websocket-extensions/lib/websocket_extensions.js:133:20)
  at Client._emitMessage (/app/node_modules/websocket-driver/lib/websocket/driver/hybi.js:445:22)
  at Client._emitFrame (/app/node_modules/websocket-driver/lib/websocket/driver/hybi.js:405:19)
  at Client.parse (/app/node_modules/websocket-driver/lib/websocket/driver/hybi.js:141:18)
  at Client.parse (/app/node_modules/websocket-driver/lib/websocket/driver/client.js:62:58)
  at IO.write (/app/node_modules/websocket-driver/lib/websocket/streams.js:80:16)
  at Socket.ondata (node:internal/streams/readable:715:22)
  at Socket.emit (node:events:327:20)
  at addChunk (node:internal/streams/readable:304:12)
  at readableAddChunk (node:internal/streams/readable:279:9)
  at Socket.Readable.push (node:internal/streams/readable:218:10)
  at TCP.onStreamRead (node:internal/stream_base_commons:192:23)
```

Probably not a great fix, happy to patch it however you wish.