### PR TITLE
[FIX] Use WebSocket close code 4000 for manual disconnection

### DIFF
--- a/lib/clients/Rocketchat.ts
+++ b/lib/clients/Rocketchat.ts
@@ -34,7 +34,7 @@ export default class RocketChatClient extends ClientRest implements ISocket {
 
   async connect (options: ISocketOptions): Promise<any> { return (await this.socket as ISocket).connect(options) }
   async disconnect (): Promise<any> { return (await this.socket as ISocket).disconnect() }
-  async tryReopen (): Promise<any> { return (await this.socket as ISocket).tryReopen() }
+  async checkAndReopen (): Promise<any> { return (await this.socket as ISocket).checkAndReopen() }
   async onStreamData (event: string, cb: ICallback): Promise<any> { return (await this.socket as ISocket).onStreamData(event, cb) }
   async subscribe (topic: string, ...args: any[]): Promise<ISubscription> { return (await this.socket as ISocket).subscribe(topic, ...args) }
   async unsubscribe (subscription: ISubscription): Promise<any> { return (await this.socket as ISocket).unsubscribe(subscription) }

--- a/lib/drivers/ddp.ts
+++ b/lib/drivers/ddp.ts
@@ -40,6 +40,8 @@ import {
 import { hostToWS } from '../util'
 import { sha256 } from 'js-sha256'
 
+const userDisconnectCloseCode = 4000;
+
 /** Websocket handler class, manages connections and subscriptions by DDP */
 export class Socket extends EventEmitter {
   sent = 0
@@ -126,10 +128,10 @@ export class Socket extends EventEmitter {
   /** Emit close event so it can be used for promise resolve in close() */
   onClose = (e: any) => {
     try {
-      if (e?.reason !== 'disconnect') {
+      if (e?.code !== userDisconnectCloseCode) {
         this.reopen()
       }
-      this.logger.info(`[ddp] Close (${e?.code}) ${e?.reason}`)
+      this.logger.info(`[ddp] Close (${e?.code})`)
     } catch (error) {
       this.logger.error(error)
     }
@@ -167,7 +169,7 @@ export class Socket extends EventEmitter {
       await new Promise((resolve) => {
         if (this.connection) {
           this.once('close', resolve)
-          this.connection.close(1000, 'disconnect')
+          this.connection.close(userDisconnectCloseCode)
         }
       })
       .catch(this.logger.error)

--- a/lib/drivers/ddp.ts
+++ b/lib/drivers/ddp.ts
@@ -184,7 +184,7 @@ export class Socket extends EventEmitter {
     return Promise.resolve()
   }
 
-  checkAndReopen = () => !this.alive() && this.reopen()
+  checkAndReopen = () => !this.connected && this.reopen()
 
   /** Clear connection and try to connect again. */
   reopen = async () => {

--- a/lib/drivers/index.ts
+++ b/lib/drivers/index.ts
@@ -16,7 +16,7 @@ export interface ISocket {
   logger: ILogger
   connect (options: ISocketOptions): Promise<ISocket | IDriver>
   disconnect (): Promise<ISocket>
-  tryReopen (): Promise<ISocket>
+  checkAndReopen (): Promise<ISocket>
   subscribe (topic: string, ...args: any[]): Promise<ISubscription>
   unsubscribe (subscription: ISubscription): Promise<ISocket>
   unsubscribeAll (): Promise<ISocket>


### PR DESCRIPTION
Instead of using code 1000, which is a `Normal Closure`, let's use one of the available for application codes (4000-4999).
This PR changes it to use 4000 and checks for it directly instead of using 1000 and checking for `disconnect` reason.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent