### PR TITLE
[NATIVE-1476] Apply mobile patch from Rocket.Chat.ReactNative

### DIFF
--- a/lib/clients/Rocketchat.ts
+++ b/lib/clients/Rocketchat.ts
@@ -6,6 +6,7 @@ export default class RocketChatClient extends ClientRest implements ISocket {
   userId: string = ''
   logger: ILogger = Logger
   socket: Promise<ISocket | IDriver>
+  ddp?: any
   config: any
 
   constructor ({ logger, allPublic, rooms, integrationId, protocol = Protocols.DDP, ...config }: any) {
@@ -16,7 +17,10 @@ export default class RocketChatClient extends ClientRest implements ISocket {
       //   this.socket = import(/* webpackChunkName: 'mqtt' */ '../drivers/mqtt').then(({ MQTTDriver }) => new MQTTDriver({ ...config, logger }))
       //   break
       case Protocols.DDP:
-        this.socket = import(/* webpackChunkName: 'ddp' */ '../drivers/ddp').then(({ DDPDriver }) => new DDPDriver({ ...config, logger }))
+        this.socket = import(/* webpackChunkName: 'ddp' */ '../drivers/ddp').then(({ DDPDriver }) => {
+          this.ddp = new DDPDriver({ ...config, logger })
+          return this.ddp
+        })
         break
       default:
         throw new Error(`Invalid Protocol: ${protocol}, valids: ${Object.keys(Protocols).join()}`)

--- a/lib/drivers/ddp.ts
+++ b/lib/drivers/ddp.ts
@@ -55,6 +55,7 @@ export class Socket extends EventEmitter {
   connection?: WebSocket
   session?: string
   logger: ILogger
+  reopenPromise?: Promise<void>
 
   /** Create a websocket handler */
   constructor (
@@ -82,17 +83,12 @@ export class Socket extends EventEmitter {
   }
 
   /**
-   * Open websocket connection, with optional retry interval.
-   * Stores connection, setting up handlers for open/close/message events.
-   * Resumes login if given token.
+   * Create a new WebSocket, tear down any previous one, and wire up handlers.
+   * Emits 'connecting' exactly once per actual new socket.
    */
-  open = (ms: number = this.config.reopen) => {
-    return new Promise(async (resolve, reject) => {
+  private createConnection = (): Promise<WebSocket> => {
+    return new Promise((resolve, reject) => {
       let connection: WebSocket
-
-      if (this.connected) {
-        return resolve()
-      }
 
       try {
         connection = new WebSocket(this.host, null, { headers: settings.customHeaders })
@@ -101,11 +97,50 @@ export class Socket extends EventEmitter {
         this.logger.error(err)
         return reject(err)
       }
+      // Tear down the previous connection before replacing it.
+      // Callers only reach here when the existing socket isn't healthy, so
+      // detaching its handlers and closing it stops a stale or still-connecting
+      // socket from later firing onClose and clobbering the live connection.
+      if (this.connection) {
+        try {
+          this.connection.onopen = null as any
+          this.connection.onmessage = null as any
+          this.connection.onerror = null as any
+          this.connection.onclose = null as any
+          this.connection.close(userDisconnectCloseCode)
+        } catch (err) {
+          this.logger.debug(`[ddp] open: previous connection teardown failed: ${(err as Error).message}`)
+        }
+      }
       this.connection = connection
       this.connection.onmessage = this.onMessage.bind(this)
-      this.connection.onclose = this.onClose.bind(this)
+      this.connection.onclose = (ev: any) => this.onClose(ev, connection) // pass closing socket so onClose can compare identity
       this.connection.onopen = this.onOpen.bind(this, resolve)
       this.emit('connecting')
+    })
+  }
+
+  /**
+   * Open websocket connection, with optional retry interval.
+   * Stores connection, setting up handlers for open/close/message events.
+   * Resumes login if given token.
+   */
+  open = (ms: number = this.config.reopen) => {
+    return new Promise(async (resolve, reject) => {
+      if (this.connected) {
+        return resolve()
+      }
+
+      if (this.reopenPromise) {
+        return this.reopenPromise.then(() => resolve(this.connection)).catch(reject)
+      }
+
+      try {
+        await this.createConnection()
+        resolve(this.connection)
+      } catch (err) {
+        reject(err)
+      }
     })
   }
 
@@ -125,7 +160,14 @@ export class Socket extends EventEmitter {
   }
 
   /** Emit close event so it can be used for promise resolve in close() */
-  onClose = (e: any) => {
+  onClose = (e: any, closedConnection?: WebSocket) => {
+    // Ignore close events from a socket we've already replaced (an
+    // orphan). Only the current connection's close should flip app state or trigger a
+    // reopen; otherwise a zombie socket's late close clobbers the live connection and
+    // the app falsely shows "Waiting for network".
+    if (closedConnection && closedConnection !== this.connection) {
+      return
+    }
     this.emit('close', e)
     try {
       if (e?.code !== userDisconnectCloseCode) {
@@ -201,6 +243,85 @@ export class Socket extends EventEmitter {
     }, this.config.reopen);
   }
 
+  /**
+   * Force an immediate reconnect. Shared across concurrent callers so only one
+   * new WebSocket is created. Emits 'disconnected' to unblock in-flight sends,
+   * then creates the connection directly so a concurrent open() cannot tear it
+   * down. Unhandled creation errors are swallowed because cleanup already runs
+   * via the open/timeout paths.
+   */
+  reopenNow = (): Promise<void> => {
+    if (this.reopenPromise) {
+      return this.reopenPromise
+    }
+
+    this.reopenPromise = new Promise<void>(resolve => {
+      this.openTimeout && clearTimeout(this.openTimeout as any)
+      this.lastPing = 0
+      this.emit('disconnected')
+
+      let settled = false
+      const cleanup = () => {
+        if (settled) return
+        settled = true
+        this.off('open', cleanup)
+        if (timeout) clearTimeout(timeout as any)
+        delete this.reopenPromise
+        resolve()
+      }
+
+      this.once('open', cleanup)
+
+      this.createConnection().catch(() => {})
+
+      const timeout = setTimeout(() => cleanup(), 10000)
+    })
+
+    return this.reopenPromise
+  }
+
+  /**
+   * Bounded liveness check for a socket in the gray zone. Returns true only if
+   * the socket is open and the server answers the ping within the deadline.
+   */
+  probe = (timeoutMs = 2000): Promise<boolean> => {
+    return new Promise<boolean>(resolve => {
+      if (!this.connection || this.connection.readyState !== 1) {
+        return resolve(false)
+      }
+
+      const lastPingAtStart = this.lastPing
+
+      let settled = false
+      const cleanup = () => {
+        if (settled) return
+        settled = true
+        this.off('pong', onPong)
+        if (timeout) clearTimeout(timeout as any)
+      }
+
+      const onPong = () => {
+        if (this.lastPing <= lastPingAtStart) return
+        cleanup()
+        resolve(true)
+      }
+
+      this.once('pong', onPong)
+
+      const timeout = setTimeout(() => {
+        cleanup()
+        resolve(false)
+      }, timeoutMs)
+
+      try {
+        this.connection.send(JSON.stringify({ msg: 'ping' }))
+      } catch {
+        cleanup()
+        resolve(false)
+      }
+    })
+  }
+
   /** Check if websocket connected and ready. */
   get connected () {
     return !!(
@@ -254,7 +375,7 @@ export class Socket extends EventEmitter {
         return resolve()
       }
       this.once(listener, (result: any) => {
-        this.off('disconnect', reject)
+        this.off('disconnected', reject)
         return (result.error ? reject(result.error) : resolve({ ...(/connect|ping|pong/.test(obj.msg) ? {} : { id }) , ...result }))
       })
     })
@@ -447,7 +568,7 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
       ...config,
       ...moreConfigs,
       host: host.replace(/(^\w+:|^)\/\//, ''),
-      timeout: 20000
+      timeout: 10000
 			// reopen: number
 			// ping: number
 			// close: number
@@ -503,6 +624,22 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
     return this.ddp.checkAndReopen()
   }
 
+  reopenNow = (): Promise<void> => {
+    return this.ddp.reopenNow()
+  }
+
+  probe = (timeoutMs?: number): Promise<boolean> => {
+    return this.ddp.probe(timeoutMs)
+  }
+
+  get lastPing (): number {
+    return this.ddp.lastPing
+  }
+
+  get pingInterval (): number {
+    return this.ddp.config.ping
+  }
+
   subscribe = (topic: string, eventname: string, ...args: any[]): Promise<ISubscription> => {
     this.logger.info(`[DDP driver] Subscribing to ${topic} | ${JSON.stringify(args)}`)
     return this.ddp.subscribe(topic, [eventname, { 'useCollection': false, 'args': args }])
@@ -549,8 +686,68 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
       'uiInteraction',
       'e2ekeyRequest',
       'userData',
-      'video-conference'
+      'video-conference',
+      'media-signal',
+      'media-calls'
     ].map(event => this.subscribe(topic, `${this.userId}/${event}`, false)))
+  }
+
+  /**
+   * Re-send the user's media-signal and media-calls subscriptions on the current
+   * socket and resolve when the server acks them with `ready`. This gives the app
+   * an observable readiness signal after a forced reconnect.
+   *
+   * If the subscriptions are not yet present (e.g. immediately after reopenNow),
+   * it polls the socket subscription map until they appear or the timeout expires.
+   */
+  waitForNotifyUserMediaSubs = (timeoutMs = 8000): Promise<boolean> => {
+    if (!this.userId) {
+      return Promise.resolve(false)
+    }
+    const topic = 'stream-notify-user'
+    const names = ['media-signal', 'media-calls']
+    const userId = this.userId
+    const findSubs = () => Object.keys(this.ddp.subscriptions || {})
+      .map(id => this.ddp.subscriptions[id])
+      .filter((sub: any) => (
+        sub &&
+        sub.name === topic &&
+        names.some(name => sub.params?.[0] === `${userId}/${name}`)
+      ))
+    // Go through the raw socket: the driver's subscribe() wrapper reshapes its
+    // arguments and would drop the subscription id, making the server treat the
+    // resubscribe as a brand new subscription.
+    const resubscribe = (subs: any[]) => Promise.all(
+      subs.map((sub: any) => this.ddp.subscribe(topic, sub.params, undefined, sub.id))
+    )
+      .then(() => true)
+      .catch(() => false)
+    return new Promise<boolean>(resolve => {
+      let settled = false
+      let inFlight = false
+      const finish = (value: boolean) => {
+        if (settled) return
+        settled = true
+        clearInterval(poll)
+        clearTimeout(deadline)
+        resolve(value)
+      }
+      const attempt = () => {
+        if (inFlight) return
+        const subs = findSubs()
+        const allPresent = names.every(name => subs.some((sub: any) => sub.params?.[0] === `${userId}/${name}`))
+        if (allPresent) {
+          inFlight = true
+          resubscribe(subs).then(value => {
+            inFlight = false
+            finish(value)
+          })
+        }
+      }
+      const deadline = setTimeout(() => finish(false), timeoutMs)
+      const poll = setInterval(attempt, 100)
+      attempt()
+    })
   }
 
   subscribeRoom = (rid: string, ...args: any[]): Promise<ISubscription[]> => {


### PR DESCRIPTION
Applies `patches/@rocket.chat+sdk+1.3.3-mobile.patch` from the Rocket.Chat.ReactNative repo directly onto the `mobile` branch, so the changes live in the SDK instead of a client-side patch.

Files touched:
- `lib/drivers/ddp.ts`
- `lib/clients/Rocketchat.ts`

Patch source: RocketChat/Rocket.Chat.ReactNative@e1db624c16388a80c91fb3380d2a0a327915b6e2 (`develop`, 2026-07-31) — "fix(voip): reconnect stale socket before native call accept (#7526)", the last commit to touch that patch file.

Ticket: https://rocketchat.atlassian.net/browse/NATIVE-1476